### PR TITLE
Custom exceptions instead of sys.exit in Hiscores

### DIFF
--- a/OSRSBytes/Hiscores.py
+++ b/OSRSBytes/Hiscores.py
@@ -19,7 +19,6 @@ throttling or IP Banning the script that's making these API Calls.  Caching is h
 import http.client
 import math
 import os
-from sys import exit
 import shelve
 import time
 
@@ -39,6 +38,12 @@ __status__     = 'Open'
 #  Exceptions  #
 ################
 class DoNotRunDirectly(Exception):
+	pass
+
+class SkillError(Exception):
+	pass
+
+class HiscoresError(Exception):
 	pass
 
 ############################
@@ -331,17 +336,14 @@ class Hiscores(object):
 		"""
 		try:
 			if stype.lower() not in ['rank','level','experience','exp_to_next_level']:
-				print("stype must be 'rank','level', or experience'")
-				exit(0)
+				SkillError("stype must be 'rank','level', or experience'")
 			else:
 				return self.stats[self.username][skill.lower()][stype.lower()]
 		except KeyError as KE:
-			print("ERROR: skill {} does not exist".format(KE))
-			exit(0)
+			SkillError("ERROR: skill {} does not exist".format(KE))
 
 	def error(self):
-		print("Error occurred: {}".format(self.errorMsg))
-		exit(0)
+		HiscoresError("Error occurred: {}".format(self.errorMsg))
 	##########################
 	#  END: Hiscores Object  #
 	##########################


### PR DESCRIPTION
### Issue

1. Due to sys.exit() calls in `Hiscores.py` it is not possible to work with library in applications like Discord bots. One can use  `except SystemExit`, but in this case error message will be left out of control flow (e.g. logging).

### Proposition

If `sys.exit()` is replaced by custom exception it is possible to try-except invocation of `Hiscores()` and gracefully process errors

###  Impact on current implementation

1. Program still will terminate, but with stacktrace and verbose information about cause of the error
2. According to POSIX, exit code `0` means that program has been executed successfully and didn't return any errors. Taking that fact into account, uncaught exception is even more preferable because it will result exit code 1, which indicates error in runtime.