### PR TITLE
Escape username for invalid URL characters (ie. spaces) [reworked]

### DIFF
--- a/OSRSBytes/Hiscores.py
+++ b/OSRSBytes/Hiscores.py
@@ -57,12 +57,12 @@ if __name__ == "__main__":
 ############################
 class Hiscores(object):
 	"""Hiscores class
-	
+
 	The Hiscores class deals with collecting the required
 	information needed to fetch user information from in-game
 	API.  After being supplied necessary information, Hiscores
 	class then sets self.stats dictionary with user information.
-	
+
 	Note that Methods prefixed by an underscore (_) would prefer that you stay out of their
 	living room.  This means that we'd prefer you don't call them directly and instead let the
 	class do it's job with them.  However, we're all consenting adults here, so if you need to
@@ -75,12 +75,12 @@ class Hiscores(object):
 		actype   str: The account type of the account that
 		              you want to lookup.  If not supplied
 			      this argument defaults to 'N' Normal.
-			      
+
 	Returns:
-		This object returns nothing.  Instead it sets the 
+		This object returns nothing.  Instead it sets the
 		value of self.stats with a dictionary of values
 		keyed by the skill type. Example: self.stats['attack']
-		
+
 	Example Invocation:
 		from OSRS-Hiscores import Hiscores
 		account = Hiscores('Zezima', 'N')
@@ -109,12 +109,12 @@ class Hiscores(object):
 		else:
 			# Caching disabled, continue with Connection
 			self._getHTTPResponse()
-		
+
 	def _checkCache(self):
 		"""_checkCache Method
 
 		The _checkCache method is used by the class to determine whether or not the HiscoresCache needs to be
-		updated for the user specified in object initialization.  On returning True, cache is updated.  On 
+		updated for the user specified in object initialization.  On returning True, cache is updated.  On
 		returning False, cache is not updated.
 		"""
 		if os.path.exists( Utilities().__package_dir__ + "/cache/hiscores.shelve.dat" ):
@@ -180,17 +180,17 @@ class Hiscores(object):
 
 	def _getHTTPResponse(self):
 		"""getHTTPResponse() method
-		
+
 		The getHTTPResponse() method communicates with the OSRS Hiscores API
 		and supplies the required information from self.username and
 		self.actype to pull the given users stats and hiscore information.
-		
+
 		Args:
 			self
-			
+
 		Returns:
 			None
-			
+
 		Triggers:
 			self.processResponse(): This method is always triggered, regardless
 			                        of whether or not the query to the API returned
@@ -198,41 +198,41 @@ class Hiscores(object):
 		"""
 		conn = http.client.HTTPSConnection('secure.runescape.com')
 		if self.accountType == 'N':
-			conn.request("GET", "/m=hiscore_oldschool/index_lite.ws?player={}".format(self.username))
+			conn.request("GET", "/m=hiscore_oldschool/index_lite.ws?player={}".format(self.username.replace(' ','%20')))
 			self.response = conn.getresponse()
 			self.status = self.response.status
 		elif self.accountType == 'IM':
-			conn.request("GET", "/m=hiscore_oldschool_ironman/index_lite.ws?player={}".format(self.username))
+			conn.request("GET", "/m=hiscore_oldschool_ironman/index_lite.ws?player={}".format(self.username.replace(' ','%20')))
 			self.response = conn.getresponse()
 			self.status = self.response.status
 		elif self.accountType == "UIM":
-			conn.request("GET", "/m=hiscore_oldschool_ultimate/index_lite.ws?player={}".format(self.username))
+			conn.request("GET", "/m=hiscore_oldschool_ultimate/index_lite.ws?player={}".format(self.username.replace(' ','%20')))
 			self.response = conn.getresponse()
 			self.status = self.response.status
 		elif self.accountType == "HIM":
-			conn.request("GET", "/m=hiscore_oldschool_hardcore_ironman/index_lite.ws?player={}".format(self.username))
+			conn.request("GET", "/m=hiscore_oldschool_hardcore_ironman/index_lite.ws?player={}".format(self.username.replace(' ','%20')))
 			self.response = conn.getresponse()
 			self.status = self.response.status
 		self._processResponse()
 
 	def _processResponse(self):
 		"""processResponse() method
-		
+
 		The processResponse() method processes the response received during the
 		getHTTPResponse() method.  It handles potential 404 errors, 403 errors
 		and the like and sets self.errorMsg accordingly.  On successful Response
 		data is stored in self.data and sent to the self.parseData() method.
-		
+
 		Args:
 			self
-			
+
 		Returns:
 			None
-			
+
 		Triggers:
 			self.error(): This method is triggered whenever the self.status of
 			              a request is not 200 (failed).
-				      
+
 			self.parseData(): This method is called when self.status is 200 (success)
 		"""
 		if self.status != 200:
@@ -244,16 +244,16 @@ class Hiscores(object):
 
 	def _parseData(self):
 		"""parseData() method
-		
+
 		The parseData() method parses the self.data processed in the processResponse()
 		method.  Data parsed in placed in the self.stats dictionary.
-		
+
 		Args:
 			self
-			
+
 		Returns:
 			None
-			
+
 		Triggers:
 			None
 		"""
@@ -309,7 +309,7 @@ class Hiscores(object):
 		self.stats = {}
 		self.stats[self.username] = subset
 		self.stats[self.username]['cache_ttl'] = time.time() + self.cacheTTL
-		
+
 		# Check for caching
 		if self.caching:
 			self._cacheData()
@@ -317,22 +317,22 @@ class Hiscores(object):
 
 	def skill(self, skill, stype: str = 'level'):
 		"""skill() method
-		
+
 		The skill() method is a more dynamic, intuitive way to access stats
 		then the self.stats dictionary variable.  It allows for a user to
 		provide the skill and stype (level, rank, experience) of the skill
 		they wish information on.
-		
+
 		Args:
 			skill (str): The OSRS skill to get information on
-			
+
 			stype (str): One of 'level', 'rank', or 'experience'
 			             to receive information for.  If not
 				     supplied, stype is assumed to be
 				     'level'
 		Returns:
 			self.stats[skill][stype] (int): The info you requested
-		
+
 		"""
 		try:
 			if stype.lower() not in ['rank','level','experience','exp_to_next_level']:


### PR DESCRIPTION
Using ```.replace(' ', '%20')``` as recommended. Same results as previous pull request.

Before:
![image](https://user-images.githubusercontent.com/5776857/111578964-b3f6fc00-877a-11eb-8c94-d9a154c1d985.png)


After:
![image](https://user-images.githubusercontent.com/5776857/111578991-c2451800-877a-11eb-9feb-956f291df936.png)
