### PR TITLE
Allow either spelling of defence / defense.

### DIFF
--- a/OSRSBytes/Hiscores.py
+++ b/OSRSBytes/Hiscores.py
@@ -183,7 +183,7 @@ class Hiscores(object):
             
         self.__skills = [
                 'attack',
-                'defense',
+                'defence',
                 'strength',
                 'hitpoints',
                 'ranged',

--- a/OSRSBytes/Hiscores.py
+++ b/OSRSBytes/Hiscores.py
@@ -387,6 +387,8 @@ class Hiscores(object):
 
         """
         try:
+            # Add support for both British and American spellings of 'defence'
+            if skill == 'defense': skill = 'defence'
             if stype.lower() not in ['rank','level','experience','exp_to_next_level']:
                 raise SkillError("stype must be 'rank','level', or experience'")
             else:


### PR DESCRIPTION
Skill list updated to reflect consistent spelling with OSRS game and hiscores but also added the ability to use US spelling for flexibility and to prevent breaking any current integrations.