### PR TITLE
Update Hiscores.py to include 'sailing'

### DIFF
--- a/OSRSBytes/Hiscores.py
+++ b/OSRSBytes/Hiscores.py
@@ -209,7 +209,8 @@ class Hiscores(object):
                 'farming',
                 'runecrafting',
                 'hunter',
-                'construction'
+                'construction',
+                'sailing'
         ]
 
         for skill in self.__skills:
@@ -490,3 +491,4 @@ class Hiscores(object):
     def getBossGenerator(self):
         for boss in self.__bosses:
             yield boss
+


### PR DESCRIPTION
Jagex recently introduced Sailing as a 24th skill, and the hiscores API now includes it in the standard skill list.